### PR TITLE
Implement focuser motion in separate thread to make it interruptable.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ include_directories(${INDI_INCLUDE_DIR})
 include(CMakeCommon)
 
 set(GPIO_LIBRARIES "libgpiod.so")
+set(PTHREAD_LIBRARIES "libpthread.so")
 
 ################ Astroberry System ################
 set(indi_astroberry_system_SRCS
@@ -47,7 +48,7 @@ IF (UNITY_BUILD)
 ENDIF ()
 
 add_executable(indi_astroberry_focuser ${indi_astroberry_focuser_SRCS})
-target_link_libraries(indi_astroberry_focuser ${INDI_DRIVER_LIBRARIES} ${GPIO_LIBRARIES})
+target_link_libraries(indi_astroberry_focuser ${INDI_DRIVER_LIBRARIES} ${GPIO_LIBRARIES} ${PTHREAD_LIBRARIES})
 install(TARGETS indi_astroberry_focuser RUNTIME DESTINATION bin )
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/indi_astroberry_focuser.xml DESTINATION ${INDI_DATA_DIR})
 

--- a/astroberry_focuser.h
+++ b/astroberry_focuser.h
@@ -82,8 +82,7 @@ private:
 	ISwitchVectorProperty TemperatureCompensateSP;
 
 	//interruptible motion thread-related fields and methods
-	std::atomic<bool> focuserMoving;
-	std::atomic<bool> focuserCompleted;
+	std::atomic<int> focuserStatus;
 	std::atomic<int> threadFocuserAbs;
 	int threadTicksToMove;
 	int threadStepDelay;

--- a/astroberry_focuser.h
+++ b/astroberry_focuser.h
@@ -19,6 +19,7 @@
 #ifndef FOCUSRPI_H
 #define FOCUSRPI_H
 
+#include <atomic>
 #include <indifocuser.h>
 
 class AstroberryFocuser : public INDI::Focuser
@@ -79,6 +80,16 @@ private:
 	INumberVectorProperty TemperatureCoefNP;
 	ISwitch TemperatureCompensateS[2];
 	ISwitchVectorProperty TemperatureCompensateSP;
+
+	//interruptible motion thread-related fields and methods
+	std::atomic<bool> focuserMoving;
+	std::atomic<bool> focuserCompleted;
+	std::atomic<int> threadFocuserAbs;
+	int threadTicksToMove;
+	int threadStepDelay;
+	bool threadReverse;
+	int threadBacklash;
+	void movingThreadCode();
 
 	struct gpiod_chip *chip;
 	struct gpiod_line *gpio_dir;


### PR DESCRIPTION
Hi,

this is my first try at implementing background/interruptible focuser motion in astroberry_focuser. 
Basically:
 - prepare data for the bg thread: put related properties values (backlash, step delay, etc) in fields used esclusively by the bg thread
 - start thread with actual gpio banging
 - periodically check status (running, position) in TimerHit, using some atomics shared with bg thread, and updating props (AbsPosition,...).
 - Do final props update and other housekeeping (save position, log, etc) when bg thread completed its work (or it's aborted).

For you to review and merge if appropriate.

Regards
Matteo
